### PR TITLE
Correcting an error when initialising "chipset"

### DIFF
--- a/LucyRTL8125Ethernet/LucyRTL8125Ethernet.hpp
+++ b/LucyRTL8125Ethernet/LucyRTL8125Ethernet.hpp
@@ -294,7 +294,7 @@ private:
     void setPCI99_180ExitDriverPara();
     void hardwareD3Para();
     UInt16 getEEEMode();
-    void exitOOB();
+    void exitOOB(bool doAll = true);
     void powerDownPLL();
     
     /* Descriptor related methods. */

--- a/LucyRTL8125Ethernet/LucyRTL8125Hardware.cpp
+++ b/LucyRTL8125Ethernet/LucyRTL8125Hardware.cpp
@@ -163,8 +163,9 @@ bool LucyRTL8125::initRTL8125()
         DebugLog("Unsupported chip found. Aborting...\n");
         goto done;
     }
-    tp->chipset =  tp->mcfg;
     
+    for (tp->chipset = 0; rtl_chip_info[tp->chipset].mcfg != tp->mcfg; tp->chipset++);
+
     /* Setup EEE support. */
     tp->eee_adv_t = eeeCap = (MDIO_EEE_100TX | MDIO_EEE_1000T);
     

--- a/LucyRTL8125Ethernet/LucyRTL8125Hardware.cpp
+++ b/LucyRTL8125Ethernet/LucyRTL8125Hardware.cpp
@@ -351,9 +351,9 @@ bool LucyRTL8125::initRTL8125()
     tp->eee_enabled = eee_enable;
     tp->eee_adv_t = MDIO_EEE_1000T | MDIO_EEE_100TX;
     
-    exitOOB();
+    exitOOB(false);
     rtl8125_hw_init(tp);
-    rtl8125_nic_reset(tp);
+    rtl8125_nic_reset(tp, false);
     
     /* Get production from EEPROM */
     rtl8125_eeprom_type(tp);
@@ -1149,7 +1149,7 @@ UInt16 LucyRTL8125::getEEEMode()
     }
     return eee;
 }
-void LucyRTL8125::exitOOB()
+void LucyRTL8125::exitOOB(bool doAll)
 {
     struct rtl8125_private *tp = &linuxData;
     UInt16 data16;
@@ -1175,7 +1175,7 @@ void LucyRTL8125::exitOOB()
             break;
     }
 
-    rtl8125_nic_reset(tp);
+    rtl8125_nic_reset(tp, doAll);
 
     switch (tp->mcfg) {
         case CFG_METHOD_2:

--- a/LucyRTL8125Ethernet/LucyRTL8125Linux-900304.cpp
+++ b/LucyRTL8125Ethernet/LucyRTL8125Linux-900304.cpp
@@ -2705,16 +2705,17 @@ rtl8125_irq_mask_and_ack(struct rtl8125_private *tp)
 #endif /* DISABLED_CODE */
 
 void
-rtl8125_nic_reset(struct net_device *dev)
+rtl8125_nic_reset(struct net_device *dev, bool doAll)
 {
         struct rtl8125_private *tp = netdev_priv(dev);
         int i;
 
         RTL_W32(tp, RxConfig, (RX_DMA_BURST << RxCfgDMAShift));
 
+    if (doAll) {
         rtl8125_enable_rxdvgate(dev);
-
         rtl8125_wait_txrx_fifo_empty(dev);
+    }
 
         switch (tp->mcfg) {
         case CFG_METHOD_2:
@@ -3463,6 +3464,10 @@ rtl8125_set_hw_wol(struct net_device *dev, u32 wolopts)
                         rtl8125_enable_magic_packet(dev);
                 else
                         rtl8125_disable_magic_packet(dev);
+                break;
+            default:
+                tmp = 0;
+                DebugLog("BB Error Tmp undefined");
                 break;
         }
 

--- a/LucyRTL8125Ethernet/LucyRTL8125Linux-900304.hpp
+++ b/LucyRTL8125Ethernet/LucyRTL8125Linux-900304.hpp
@@ -1885,7 +1885,7 @@ int rtl8125_disable_eee_plus(struct rtl8125_private *tp);
 int rtl8125_enable_eee(struct rtl8125_private *tp);
 int rtl8125_disable_eee(struct rtl8125_private *tp);
 
-void rtl8125_nic_reset(struct net_device *dev);
+void rtl8125_nic_reset(struct net_device *dev, bool doAll = true);
 void rtl8125_get_mac_version(struct rtl8125_private *tp);
 void rtl8125_xmii_reset_enable(struct net_device *dev);
 unsigned int rtl8125_xmii_reset_pending(struct net_device *dev);


### PR DESCRIPTION
chipset of rtl8125_private is not set correctly. This will lead to the driver working only with some chips.